### PR TITLE
use hot pink for errors

### DIFF
--- a/colors/angr.vim
+++ b/colors/angr.vim
@@ -98,8 +98,8 @@ hi IncSearch guifg=#c0c0c0 ctermfg=7 guibg=#005fff ctermbg=27  gui=NONE cterm=NO
 hi Search    guifg=#c0c0c0 ctermfg=7 guibg=#df005f ctermbg=161 gui=NONE cterm=NONE
 
 " Messages {{{1
-hi Error      guifg=#eeeeee ctermfg=255 guibg=#df0000 ctermbg=160  gui=NONE cterm=NONE
-hi ErrorMsg   guifg=#eeeeee ctermfg=255 guibg=#df0000 ctermbg=160  gui=NONE cterm=NONE
+hi Error      guifg=#eeeeee ctermfg=255 guibg=#df005f ctermbg=161  gui=NONE cterm=NONE
+hi ErrorMsg   guifg=#eeeeee ctermfg=255 guibg=#df005f ctermbg=161  gui=NONE cterm=NONE
 hi ModeMsg    guifg=#afff87 ctermfg=156               ctermbg=NONE gui=bold cterm=bold
 hi MoreMsg    guifg=#c0c0c0 ctermfg=7   guibg=#005fdf ctermbg=26   gui=NONE cterm=NONE
 hi WarningMsg guifg=#c0c0c0 ctermfg=7   guibg=#005fdf ctermbg=26   gui=NONE cterm=NONE


### PR DESCRIPTION
I didn't see the Error red `#df0000` used anywhere including the screenshot.

I've been working on this [vim-airline-theme for angr](https://github.com/watsoncj/vim-airline-themes/blob/master/autoload/airline/themes/angr.vim) and noticed that the `#df0000` seems out of place.

<img width="926" alt="screen shot 2017-02-15 at 4 41 18 pm" src="https://cloud.githubusercontent.com/assets/31694/23000600/855b59fa-f39e-11e6-9a76-130795a41bda.png">

Feel free to close this if I'm just misunderstanding the purpose of the `Error`/`ErrorMsg` red.
